### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ homepage = "https://github.com/smol-rs/futures-lite"
 documentation = "https://docs.rs/futures-lite"
 keywords = ["asynchronous", "futures", "async"]
 categories = ["asynchronous", "concurrency"]
-readme = "README.md"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.