### PR TITLE
Allow a BufReader that wraps an AsyncWrite to be AsyncWrite

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -701,6 +701,24 @@ impl<R: AsyncSeek> AsyncSeek for BufReader<R> {
     }
 }
 
+impl<R: AsyncWrite> AsyncWrite for BufReader<R> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize>> {
+        self.as_mut().get_pin_mut().poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.as_mut().get_pin_mut().poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.as_mut().get_pin_mut().poll_close(cx)
+    }
+}
+
 pin_project! {
     /// Adds buffering to a writer.
     ///


### PR DESCRIPTION
This allows full-duplex io through the BufReader wrapper without needing to clone an AsyncRead+AsyncWrite or introduce a mutex with [io::split](https://docs.rs/futures-lite/1.11.3/futures_lite/io/fn.split.html)

Thanks!