### PR TITLE
Remove unused variable in sample documentation

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -1465,7 +1465,6 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     /// let mut reader = BufReader::new(input);
     /// let mut lines = reader.lines();
     ///
-    /// let mut line = String::new();
     /// while let Some(line) = lines.next().await {
     ///     println!("{}", line?);
     /// }


### PR DESCRIPTION
`line` is actually declared later in `while let ...`, so this line is not necessary 

```
warning: unused variable: `line`
   --> src/mpv.rs:125:9
    |
125 |     let mut line = String::new();
    |         ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_line`
```