### PR TITLE
Support BlockOn for implementors of AsyncBufRead

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -394,6 +394,16 @@ impl<T: AsyncRead + Unpin> std::io::Read for BlockOn<T> {
     }
 }
 
+impl<T: AsyncBufRead + Unpin> std::io::BufRead for BlockOn<T> {
+    fn fill_buf(&mut self) -> Result<&[u8]> {
+        future::block_on(self.0.fill_buf())
+    }
+
+    fn consume(&mut self, amt: usize) {
+        Pin::new(&mut self.0).consume(amt)
+    }
+}
+
 impl<T: AsyncWrite + Unpin> std::io::Write for BlockOn<T> {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         future::block_on(self.0.write(buf))


### PR DESCRIPTION
Even though I am a bit suspicious that there might be a reason this wasn't implemented before, here I go with a first draft on adding support for AsyncBufRead -> std::io::BufRead in `BlockOn`.

Please let me know in case its absence is intended or what else I could do to make this PR ready for merge. Thanks a lot.

_Related to https://github.com/Byron/gitoxide/issues/77_ 