### PR TITLE
Replace parking with std::thread::park

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["/.*"]
 
 [features]
 default = ["std"]
-std = ["alloc", "fastrand", "futures-io", "parking", "memchr", "waker-fn"]
+std = ["alloc", "fastrand", "futures-io", "memchr", "waker-fn"]
 alloc = []
 
 [dependencies]
@@ -29,7 +29,6 @@ fastrand = { version = "1.3.4", optional = true }
 futures-core = { version = "0.3.5", default-features = false }
 futures-io = { version = "0.3.5", optional = true }
 memchr = { version = "2.3.3", optional = true }
-parking = { version = "2.0.0", optional = true }
 pin-project-lite = "0.2.0"
 waker-fn = { version = "1.0.0", optional = true }
 

--- a/src/future.rs
+++ b/src/future.rs
@@ -64,9 +64,7 @@ pub fn block_on<T>(future: impl Future<Output = T>) -> T {
         // Cached parker and waker for efficiency.
         static CACHE: Waker = {
             let thread = std::thread::current();
-            waker_fn(move || {
-                thread.unpark();
-            })
+            waker_fn(move || thread.unpark())
         };
     }
 


### PR DESCRIPTION
`parking` adds extra compile time for something that's already available in the std lib. This PR replaces `parking` with `std::thread::park` and `Thread::unpark` when using `future::block_on`.  It has also gotten signfigant platform-specific improvements that `parking` lacks. This might add one additional thread local lookup when the thread is parked, but if you're parking the thread anyway, I don't think that overhead really matters.