### PR TITLE
Implement `for_each_concurrent()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ exclude = ["/.*"]
 
 [features]
 default = ["std"]
-std = ["alloc", "fastrand", "futures-io", "parking", "memchr", "waker-fn"]
-alloc = []
+std = ["alloc", "fastrand", "futures-io", "parking", "memchr"]
+alloc = ["waker-fn"]
 
 [dependencies]
 fastrand = { version = "1.3.4", optional = true }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -3068,10 +3068,17 @@ where
 
             // Try to get the next value from the stream.
             if !*this.empty {
-                if let Poll::Ready(Some(fut)) = (&mut this.stream).poll_next(cx) {
-                    // We got a value, push it into the queue.
-                    this.futures.push((this.f)(fut));
-                    *this.empty = true;
+                if let Poll::Ready(value) = (&mut this.stream).poll_next(cx) {
+                    match value {
+                        Some(value) => {
+                            // We got a value, push it into the queue.
+                            this.futures.push((this.f)(value));
+                        }
+                        None => {
+                            *this.empty = true;
+                        }
+                    }
+
                     made_progress = true;
                 }
             }
@@ -3118,6 +3125,7 @@ where
 
             // First, poll all the futures that we're currently running.
             if let Poll::Ready(Some(res)) = self.futures.poll_next(cx) {
+                // Propagate the error if we got one.
                 res?;
 
                 // Re-run the loop to keep polling futures.
@@ -3134,10 +3142,17 @@ where
                     ref mut futures,
                 } = &mut *self;
 
-                if let Poll::Ready(Some(fut)) = stream.poll_next(cx) {
-                    // We got a value, push it into the queue.
-                    futures.push((f)(fut));
-                    *empty = true;
+                if let Poll::Ready(value) = stream.poll_next(cx) {
+                    match value {
+                        Some(value) => {
+                            // We got a value, push it into the queue.
+                            futures.push((f)(value));
+                        }
+                        None => {
+                            *empty = true;
+                        }
+                    }
+
                     made_progress = true;
                 }
             }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -3030,7 +3030,7 @@ where
 #[cfg(feature = "alloc")]
 pin_project! {
     /// Future for the [`StreamExt::for_each_concurrent()`] method.
-    #[derive(Debug)] 
+    #[derive(Debug)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct ForEachConcurrentFuture<Fut, S, F> {
         #[pin]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1515,7 +1515,7 @@ pub trait StreamExt: Stream {
     ///
     /// # spin_on::spin_on(async {
     /// let mut s = stream::iter(vec![1, 2, 3]);
-    /// s.for_each_concurrent(2, |s| async move {
+    /// s.for_each_concurrent(|s| async move {
     ///     println!("{}", s);
     /// }).await;
     /// # });
@@ -3055,6 +3055,11 @@ where
         let mut made_progress = false;
 
         loop {
+            // If we're empty, we're done.
+            if *this.empty && this.futures.is_empty() {
+                return Poll::Ready(());
+            }
+
             // First, poll all the futures that we're currently running.
             if let Poll::Ready(Some(())) = this.futures.poll_next(cx) {
                 // Re-run the loop to keep polling futures.
@@ -3073,11 +3078,6 @@ where
 
             // If we made no progress on this iteration of the loop, return.
             if !made_progress {
-                // If we're empty, we're done.
-                if *this.empty && this.futures.is_empty() {
-                    return Poll::Ready(());
-                }
-
                 return Poll::Pending;
             }
         }
@@ -3111,6 +3111,11 @@ where
         let mut made_progress = false;
 
         loop {
+            // If we're empty, we're done.
+            if self.empty && self.futures.is_empty() {
+                return Poll::Ready(Ok(()));
+            }
+
             // First, poll all the futures that we're currently running.
             if let Poll::Ready(Some(res)) = self.futures.poll_next(cx) {
                 res?;
@@ -3139,11 +3144,6 @@ where
 
             // If we made no progress on this iteration of the loop, return.
             if !made_progress {
-                // If we're empty, we're done.
-                if self.empty && self.futures.is_empty() {
-                    return Poll::Ready(Ok(()));
-                }
-
                 return Poll::Pending;
             }
         }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -3027,10 +3027,10 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 pin_project! {
     /// Future for the [`StreamExt::for_each_concurrent()`] method.
-    #[derive(Debug)]
-    #[cfg(feature = "alloc")]
+    #[derive(Debug)] 
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct ForEachConcurrentFuture<Fut, S, F> {
         #[pin]

--- a/src/stream/unordered.rs
+++ b/src/stream/unordered.rs
@@ -202,10 +202,10 @@ fn container_waker(state: &Arc<AtomicBool>, cx: &mut Context<'_>) -> Waker {
 
 #[cfg(test)]
 mod tests {
-    use super::UnorderedFutures;
-    use crate::stream::StreamExt;
     #[cfg(not(feature = "std"))]
     use super::alloc::vec::Vec;
+    use super::UnorderedFutures;
+    use crate::stream::StreamExt;
 
     // Make sure the call is tail-optimized so we don't hit the stack limit.
     #[test]

--- a/src/stream/unordered.rs
+++ b/src/stream/unordered.rs
@@ -1,0 +1,218 @@
+//! The `UnorderedFutures` stream object.
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use core::iter::FromIterator;
+use core::pin::Pin;
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::task::{Context, Poll, Waker};
+
+use crate::{Future, Stream};
+
+use pin_project_lite::pin_project;
+use waker_fn::waker_fn;
+
+/// A list of futures that polls all of them concurrently.
+///
+/// There are many cases where a set of futures need to polled.
+/// Polling them one after another is inefficient and can lead
+/// to starvation. When a future is pushed into this stream,
+/// it is polled concurrently with all the other futures.
+///
+/// The order of the output is not guaranteed.
+///
+/// # Example
+///
+/// ```rust
+/// use futures_lite::future::ready;
+/// use futures_lite::stream::{UnorderedFutures, StreamExt};
+///
+/// # spin_on::spin_on(async {
+/// let mut stream = UnorderedFutures::new();
+///
+/// for _ in 0..3 {
+///     stream.push(ready(1));
+/// }
+///
+/// let v: Vec<_> = stream.collect().await;
+/// assert_eq!(v, vec![1, 1, 1]);
+/// # });
+/// ```
+#[derive(Debug, Default, Clone)]
+#[must_use = "streams do nothing unless polled"]
+pub struct UnorderedFutures<Fut> {
+    /// The first future in our linked list to be polled.
+    first: Link<Fut>,
+    /// The current number of futures in the list.
+    len: usize,
+}
+
+pin_project! {
+    /// The state of a future in the linked list.
+    #[derive(Debug, Clone)]
+    struct Container<Fut> {
+        #[pin]
+        future: Fut,
+        next: Link<Fut>,
+        ready: Arc<AtomicBool>,
+    }
+}
+
+/// Type alias to make the code more readable.
+type Link<Fut> = Option<Pin<Box<Container<Fut>>>>;
+
+impl<Fut: Future> UnorderedFutures<Fut> {
+    /// Creates a new, empty `UnorderedFutures`.
+    pub const fn new() -> UnorderedFutures<Fut> {
+        UnorderedFutures {
+            first: None,
+            len: 0,
+        }
+    }
+
+    /// Gets the number of futures in the list.
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if the list contains no futures.
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Adds a future to the list.
+    pub fn push(&mut self, future: Fut) {
+        let mut container = Container::new(future);
+
+        // Update the linked list.
+        container.next = self.first.take();
+        self.first = Some(Box::pin(container));
+        self.len += 1;
+    }
+
+    /// The borrow checker doesn't accept this code in loop form. However,
+    /// it seems to have no issues with this recursive form.
+    fn poll_next_impl(
+        cx: &mut Context<'_>,
+        current_slot: &mut Link<Fut>,
+        len: &mut usize,
+    ) -> Poll<Option<Fut::Output>> {
+        // Poll all futures in the list.
+        if let Some(current) = current_slot.as_mut() {
+            let current = current.as_mut().project();
+
+            // If the future is ready to poll, begin polling it.
+            //
+            // Relaxed is appropriate to use here, since the stream is
+            // only re-polled in a sane executor if the waker is woken,
+            // and the value is set before the waker is woken.
+            if current.ready.load(Ordering::Relaxed) {
+                // Create the context to poll the future in.
+                //
+                // The context ensures that the future is marked as "ready"
+                // when it is woken.
+                current.ready.store(false, Ordering::Relaxed);
+                let waker = container_waker(&current.ready, cx);
+                let mut context = Context::from_waker(&waker);
+
+                // Poll the future.
+                if let Poll::Ready(value) = current.future.poll(&mut context) {
+                    // The future has completed, so remove it from the list.
+                    *current_slot = current.next.take();
+                    *len -= 1;
+                    return Poll::Ready(Some(value));
+                }
+            }
+
+            // The future is not ready, so move on to the next one.
+            Self::poll_next_impl(cx, current.next, len)
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+impl<Fut: Future> Stream for UnorderedFutures<Fut> {
+    type Item = Fut::Output;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let Self {
+            ref mut first,
+            ref mut len,
+        } = &mut *self;
+
+        // If the list is empty, return `None`.
+        if first.is_none() {
+            return Poll::Ready(None);
+        }
+
+        Self::poll_next_impl(cx, first, len)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len))
+    }
+}
+
+impl<Fut: Future> Extend<Fut> for UnorderedFutures<Fut> {
+    fn extend<T: IntoIterator<Item = Fut>>(&mut self, iter: T) {
+        for future in iter {
+            self.push(future);
+        }
+    }
+}
+
+impl<Fut: Future> FromIterator<Fut> for UnorderedFutures<Fut> {
+    fn from_iter<T: IntoIterator<Item = Fut>>(iter: T) -> Self {
+        let mut stream = UnorderedFutures::new();
+        stream.extend(iter);
+        stream
+    }
+}
+
+impl<Fut> Container<Fut> {
+    fn new(future: Fut) -> Self {
+        Self {
+            future,
+            next: None,
+            ready: Arc::new(AtomicBool::new(true)),
+        }
+    }
+}
+
+/// Create a waker for a given container's state and the global
+/// context.
+///
+/// This would normally be a method on `Container`'s pin projection,
+/// but there is no way to add associated methods to the projection.
+fn container_waker(state: &Arc<AtomicBool>, cx: &mut Context<'_>) -> Waker {
+    let state = state.clone();
+    let waker = cx.waker().clone();
+
+    waker_fn(move || {
+        // Indicate that the future is ready to be polled, and wake the top-level waker.
+        state.store(true, Ordering::SeqCst);
+        waker.wake_by_ref();
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UnorderedFutures;
+    use crate::stream::StreamExt;
+
+    // Make sure the call is tail-optimized so we don't hit the stack limit.
+    #[test]
+    fn lots_of_futures() {
+        let mut stream = UnorderedFutures::new();
+
+        for _ in 0..10000 {
+            stream.push(async { 1 });
+        }
+
+        let v: Vec<_> = spin_on::spin_on(stream.collect());
+        assert_eq!(v.len(), 10000);
+    }
+}

--- a/src/stream/unordered.rs
+++ b/src/stream/unordered.rs
@@ -63,7 +63,7 @@ pin_project! {
 /// Type alias to make the code more readable.
 type Link<Fut> = Option<Pin<Box<Container<Fut>>>>;
 
-impl<Fut: Future> UnorderedFutures<Fut> {
+impl<Fut> UnorderedFutures<Fut> {
     /// Creates a new, empty `UnorderedFutures`.
     pub const fn new() -> UnorderedFutures<Fut> {
         UnorderedFutures {
@@ -81,7 +81,9 @@ impl<Fut: Future> UnorderedFutures<Fut> {
     pub const fn is_empty(&self) -> bool {
         self.len == 0
     }
+}
 
+impl<Fut: Future> UnorderedFutures<Fut> {
     /// Adds a future to the list.
     pub fn push(&mut self, future: Fut) {
         let mut container = Container::new(future);

--- a/src/stream/unordered.rs
+++ b/src/stream/unordered.rs
@@ -204,6 +204,8 @@ fn container_waker(state: &Arc<AtomicBool>, cx: &mut Context<'_>) -> Waker {
 mod tests {
     use super::UnorderedFutures;
     use crate::stream::StreamExt;
+    #[cfg(not(feature = "std"))]
+    use super::alloc::vec::Vec;
 
     // Make sure the call is tail-optimized so we don't hit the stack limit.
     #[test]


### PR DESCRIPTION
This PR adds a new type, `UnorderedFutures`, that stores and then polls a series of futures concurrently. I then go on to use `UnorderedFutures` to implement `for_each_concurrent()` and `try_for_each_concurrent`, resolving #26.

The implementation I use here is relatively inefficient. It uses two allocations per future stored; one for the `Container`, and another for the readiness flag. In addition, another allocation is added per poll for the `waker_fn`. Ideally, it would look more like this:

```rust
pub struct UnorderedFutures<Fut> {
    first: Option<Pin<Arc<Container<Fut>>>>,
}

pin_project! {
    struct Container<Fut> {
        #[pin]
        future: Mutex<Fut>,
        next: Mutex<Option<Pin<Arc<Container<Fut>>>>>,
        ready: AtomicBool,
        waker: AtomicWaker,
    }
}

impl<Fut> Wake for Container<Fut> {
    // set the ready flag to true and then wake the waker
}
```

Note that this would add a dependency on `libstd` and `atomic-waker`, and would require unsafe code since it's impossible to get a `Pin<MutexGuard<T>>` from a `Pin<&Mutex<T>>` without unsafe code.

However, since this is an implementation detail that can be resolved through a patch bump in the future, I decided to leave it with the as-is simple implementation.