### PR TITLE
Add `buffer_mut` method to `BufWriter`

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -883,6 +883,12 @@ impl<W: AsyncWrite> BufWriter<W> {
         &self.buf
     }
 
+    /// Returns a mutable reference to the internal buffer.
+    /// This can be useful sometimes when trying to reduce the amount of copies.
+    pub fn buffer_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.buf
+    }
+
     /// Flush the buffer.
     fn poll_flush_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
         let mut this = self.project();


### PR DESCRIPTION
This can be useful sometimes when trying to reduce the amount of copies. 
My specific use case is to use the underlying buffer in a https://docs.rs/inout/0.1.2/inout/struct.InOutBuf.html for encryption. So the unencrypted data would get encrypted and immediately written to the internal buffer, which is one less copy than if I encrypted it in place or to another buffer and then wrote it to the buffer 