### PR TITLE
Add a combinator for temporarily using an AsyncRead/AsyncWrite as Read/Write

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -481,7 +481,7 @@ impl<'r, 'ctx, T> AsyncAsSync<'r, 'ctx, T> {
     /// let mut context = Context::from_waker(&waker);
     ///
     /// let mut async_reader = AsyncAsSync::new(&mut context, reader);
-    /// let (reader, context) = async_reader.into_inner();
+    /// let (reader, context) = async_reader.into_parts();
     /// ```
     #[inline]
     pub fn into_parts(self) -> (&'r mut Context<'ctx>, T) {
@@ -502,7 +502,7 @@ impl<'r, 'ctx, T> AsyncAsSync<'r, 'ctx, T> {
     /// let mut context = Context::from_waker(&waker);
     ///
     /// let mut async_reader = AsyncAsSync::new(&mut context, reader);
-    /// let reader = async_reader.into_inner_io();
+    /// let reader = async_reader.into_inner();
     /// ```
     #[inline]
     pub fn into_inner(self) -> T {
@@ -538,15 +538,17 @@ impl<'r, 'ctx, T> AsyncAsSync<'r, 'ctx, T> {
     /// # Examples
     ///
     /// ```
-    /// use futures_lite::io::{prelude::*, AsyncAsSync};
+    /// use futures_lite::io::{AsyncAsSync, AsyncRead};
+    /// use std::task::Context;
+    /// use waker_fn::waker_fn;
     ///
     /// let reader: &[u8] = b"hello";
     /// let waker = waker_fn(|| {});
     /// let mut context = Context::from_waker(&waker);
     ///
     /// let mut async_reader = AsyncAsSync::new(&mut context, reader);
-    /// let r = async_reader.poll_with(|io, cx| io.poll_read(cx, &mut [0; 1024]))?;
-    /// assert_eq!(r, Ok(5));
+    /// let r = async_reader.poll_with(|io, cx| io.poll_read(cx, &mut [0; 1024]));
+    /// assert_eq!(r.unwrap(), 5);
     /// ```
     #[inline]
     pub fn poll_with<R>(

--- a/src/io.rs
+++ b/src/io.rs
@@ -352,10 +352,10 @@ impl<T: std::io::Seek> AsyncSeek for AssertAsync<T> {
 #[derive(Debug)]
 pub struct AsyncAsSync<'r, 'ctx, T> {
     /// The context we are using to poll the future.
-    context: &'r mut Context<'ctx>,
+    pub context: &'r mut Context<'ctx>,
 
     /// The actual reader/writer we are wrapping.
-    inner: T,
+    pub inner: T,
 }
 
 impl<'r, 'ctx, T> AsyncAsSync<'r, 'ctx, T> {
@@ -377,136 +377,6 @@ impl<'r, 'ctx, T> AsyncAsSync<'r, 'ctx, T> {
     #[inline]
     pub fn new(context: &'r mut Context<'ctx>, io: T) -> Self {
         AsyncAsSync { context, inner: io }
-    }
-
-    /// Gets a reference to the inner I/O handle.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use futures_lite::io::AsyncAsSync;
-    /// use std::task::Context;
-    /// use waker_fn::waker_fn;
-    ///
-    /// let reader: &[u8] = b"hello";
-    /// let waker = waker_fn(|| {});
-    /// let mut context = Context::from_waker(&waker);
-    ///
-    /// let async_reader = AsyncAsSync::new(&mut context, reader);
-    /// let r = async_reader.get_ref();
-    /// ```
-    #[inline]
-    pub fn get_ref(&self) -> &T {
-        &self.inner
-    }
-
-    /// Gets a mutable reference to the inner I/O handle.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use futures_lite::io::AsyncAsSync;
-    /// use std::task::Context;
-    /// use waker_fn::waker_fn;
-    ///
-    /// let reader: &[u8] = b"hello";
-    /// let waker = waker_fn(|| {});
-    /// let mut context = Context::from_waker(&waker);
-    ///
-    /// let mut async_reader = AsyncAsSync::new(&mut context, reader);
-    /// let r = async_reader.get_mut();
-    /// ```
-    #[inline]
-    pub fn get_mut(&mut self) -> &mut T {
-        &mut self.inner
-    }
-
-    /// Gets a mutable reference to the asynchronous context.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use futures_lite::io::AsyncAsSync;
-    /// use std::task::Context;
-    /// use waker_fn::waker_fn;
-    ///
-    /// let reader: &[u8] = b"hello";
-    /// let waker = waker_fn(|| {});
-    /// let mut context = Context::from_waker(&waker);
-    ///
-    /// let mut async_reader = AsyncAsSync::new(&mut context, reader);
-    /// let ctx = async_reader.get_context();
-    /// ```
-    #[inline]
-    pub fn get_context(&mut self) -> &mut Context<'ctx> {
-        self.context
-    }
-
-    /// Set the asynchronous context.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use futures_lite::io::AsyncAsSync;
-    /// use std::task::Context;
-    /// use waker_fn::waker_fn;
-    ///
-    /// let reader: &[u8] = b"hello";
-    /// let waker = waker_fn(|| {});
-    /// let mut context = Context::from_waker(&waker);
-    ///
-    /// let mut async_reader = AsyncAsSync::new(&mut context, reader);
-    /// let waker = waker_fn(|| {});
-    /// let mut context = Context::from_waker(&waker);
-    ///
-    /// async_reader.set_context(&mut context);
-    /// ```
-    #[inline]
-    pub fn set_context(&mut self, context: &'r mut Context<'ctx>) {
-        self.context = context;
-    }
-
-    /// Unwraps this `AsyncAsSync`, returning the underlying I/O handle and
-    /// asynchronous context.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use futures_lite::io::AsyncAsSync;
-    /// use std::task::Context;
-    /// use waker_fn::waker_fn;
-    ///
-    /// let reader: &[u8] = b"hello";
-    /// let waker = waker_fn(|| {});
-    /// let mut context = Context::from_waker(&waker);
-    ///
-    /// let mut async_reader = AsyncAsSync::new(&mut context, reader);
-    /// let (reader, context) = async_reader.into_parts();
-    /// ```
-    #[inline]
-    pub fn into_parts(self) -> (&'r mut Context<'ctx>, T) {
-        (self.context, self.inner)
-    }
-
-    /// Unwraps this `AsyncAsSync`, returning the underlying I/O handle.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use futures_lite::io::AsyncAsSync;
-    /// use std::task::Context;
-    /// use waker_fn::waker_fn;
-    ///
-    /// let reader: &[u8] = b"hello";
-    /// let waker = waker_fn(|| {});
-    /// let mut context = Context::from_waker(&waker);
-    ///
-    /// let mut async_reader = AsyncAsSync::new(&mut context, reader);
-    /// let reader = async_reader.into_inner();
-    /// ```
-    #[inline]
-    pub fn into_inner(self) -> T {
-        self.inner
     }
 
     /// Attempt to shutdown the I/O handle.

--- a/src/io.rs
+++ b/src/io.rs
@@ -375,8 +375,8 @@ impl<'r, 'ctx, T> AsyncAsSync<'r, 'ctx, T> {
     /// let async_reader = AsyncAsSync::new(&mut context, reader);
     /// ```
     #[inline]
-    pub fn new(context: &'r mut Context<'ctx>, io: T) -> Self {
-        AsyncAsSync { context, inner: io }
+    pub fn new(context: &'r mut Context<'ctx>, inner: T) -> Self {
+        AsyncAsSync { context, inner }
     }
 
     /// Attempt to shutdown the I/O handle.


### PR DESCRIPTION
During smol-rs/async-rustls#9, @zseri pointed out that [we frequently use a type that just converts an `AsyncRead` to a `Read`](https://github.com/smol-rs/async-rustls/pull/9#discussion_r1008779510) temporarily so that it can be used in `rustls`, which only takes a `Read`. This pattern is not unique to `async-rustls`, since I've also seen this used in `tokio-tungstenite`, following a similar pattern.

In order to deduplicate instances of this pattern throughout the ecosystem, this PR implements this pattern as a type in the `io` module.