### PR TITLE
v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 1.13.0
+
+- Unbind Debug implementations of BufReader and BufWriter. (#49)
+- Add the once_future() combinator. (#59)
+- Add a combinator for temporarily using an AsyncRead/AsyncWrite as Read/Write. (#62)
+- Implement more methods for stream::BlockOn. (#68)
+
 # Version 1.12.0
 
 - Implement `BufRead` for `BlockOn`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "futures-lite"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.12.0"
+version = "1.13.0"
 authors = [
   "Stjepan Glavina <stjepang@gmail.com>",
   "Contributors to futures-rs",


### PR DESCRIPTION
- Unbind Debug implementations of BufReader and BufWriter. (#49)
- Add the once_future() combinator. (#59)
- Add a combinator for temporarily using an AsyncRead/AsyncWrite as Read/Write. (#62)
- Implement more methods for stream::BlockOn. (#68)