### PR TITLE
Add a Stream::try_iter() method

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1776,7 +1776,7 @@ pub trait StreamExt: Stream {
     /// [`Iterator`].
     ///
     /// [`try_iter`]: std::sync::mpsc::Receiver::try_iter
-    /// [`async_channel::Receiver`]: async_channel::Receiver
+    /// [`async_channel::Receiver`]: https://docs.rs/async-channel/latest/async_channel/struct.Receiver.html
     /// [`Stream`]: crate::stream::Stream
     /// [`Iterator`]: std::iter::Iterator
     ///

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1786,6 +1786,7 @@ pub trait StreamExt: Stream {
     /// use futures_lite::{future, pin};
     /// use futures_lite::stream::{self, StreamExt};
     ///
+    /// # #[cfg(feature = "std")] {
     /// // A stream that yields two values, returns `Pending`, and then yields one more value.
     /// let pend_once = stream::once_future(async {
     ///     future::yield_now().await;
@@ -1804,6 +1805,7 @@ pub trait StreamExt: Stream {
     /// // This will return the last value, because the stream returns `Ready` when polled.
     /// assert_eq!(iter.next(), Some(3));
     /// assert_eq!(iter.next(), None);
+    /// # }
     /// ```
     fn try_iter(&mut self) -> TryIter<'_, Self> {
         TryIter { stream: self }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -3244,7 +3244,7 @@ impl<'a, S: Unpin + ?Sized> TryStream<'a, S> {
     /// ```
     /// use futures_lite::{prelude::*, stream};
     ///
-    /// # futures_lite::future::block_on(async {
+    /// # spin_on::spin_on(async {
     /// let mut s = stream::iter(vec![1, 2, 3]);
     /// let s2 = s.try_stream();
     ///
@@ -3263,7 +3263,7 @@ impl<'a, S: Unpin + ?Sized> TryStream<'a, S> {
     /// ```
     /// use futures_lite::{prelude::*, stream};
     ///
-    /// # futures_lite::future::block_on(async {
+    /// # spin_on::spin_on(async {
     /// let mut s = stream::iter(vec![1, 2, 3]);
     /// let mut s2 = s.try_stream();
     ///
@@ -3282,7 +3282,7 @@ impl<'a, S: Unpin + ?Sized> TryStream<'a, S> {
     /// ```
     /// use futures_lite::{prelude::*, stream};
     ///
-    /// # futures_lite::future::block_on(async {
+    /// # spin_on::spin_on(async {
     /// let mut s = stream::iter(vec![1, 2, 3]);
     /// let mut s2 = s.try_stream();
     ///


### PR DESCRIPTION
This PR adds a `try_iter` method to `StreamExt` that consumes all of the values until it gets `Pending`, at which point it returns `None`. The goal is to get a method similar to [`Receiver::try_iter()`](https://doc.rust-lang.org/std/sync/mpsc/struct.Receiver.html#method.try_iter) on the `async_channel::Receiver` type that would allow users to consume all of the values in the channel without waiting.