### PR TITLE
Add a way to provide your own seed to racey futures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         # When updating this, the reminder to update the minimum supported
         # Rust version in Cargo.toml.
-        rust: ['1.48']
+        rust: ['1.61']
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
   "Contributors to futures-rs",
 ]
 edition = "2018"
-rust-version = "1.48"
+rust-version = "1.61"
 description = "Futures, streams, and async I/O combinators"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/smol-rs/futures-lite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,13 @@ categories = ["asynchronous", "concurrency"]
 exclude = ["/.*"]
 
 [features]
-default = ["std"]
-std = ["alloc", "fastrand", "futures-io", "parking", "memchr", "waker-fn"]
+default = ["race", "std"]
+std = ["alloc", "fastrand/std", "futures-io", "parking", "memchr", "waker-fn"]
 alloc = []
+race = ["fastrand"]
 
 [dependencies]
-fastrand = { version = "2.0.0", optional = true }
+fastrand = { version = "2.0.0", optional = true, default-features = false }
 futures-core = { version = "0.3.5", default-features = false }
 futures-io = { version = "0.3.5", optional = true }
 memchr = { version = "2.3.3", optional = true }


### PR DESCRIPTION
The race functions were not available on no_std targets. This commit
adds "with_seed" variants that take a u64 seed that is passed to
fastrand. It can be used on no_std targets to provide random racey
futures and streams.

A "race" feature is added that enables it. This way fastrand doesn't
become a dependency for crates that don't need it, like async-io.

As part of this change, each racy futures provides its own `Rng` instance.