### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Version 2.0.0
+
+- **Breaking:** Expose `future::{ready, pending}` from `core` instead of defining
+  our own. (#73)
+- **Breaking:** The `TryZip` and `Zip` combinators are modified to have a cleaner
+  API, where generic constraints are not necessary on the structure itself at the
+  cost of additional generics. (#74)
+- Add a way to use racey futures on `no_std` by providing your own seed. (#75)
+
 # Version 1.13.0
 
 - Unbind Debug implementations of BufReader and BufWriter. (#49)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "futures-lite"
 # When publishing a new version:
 # - Update CHANGELOG.md
-# - Create "v1.x.y" git tag
-version = "1.13.0"
+# - Create "v2.x.y" git tag
+version = "2.0.0"
 authors = [
   "Stjepan Glavina <stjepang@gmail.com>",
   "Contributors to futures-rs",


### PR DESCRIPTION
- **Breaking:** Expose `future::{ready, pending}` from `core` instead of defining
  our own. (#73)
- **Breaking:** The `TryZip` and `Zip` combinators are modified to have a cleaner
  API, where generic constraints are not necessary on the structure itself at the
  cost of additional generics. (#74)
- Add a way to use racey futures on `no_std` by providing your own seed. (#75)