### PR TITLE
v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.0.1
+
+- Remove dependency on the `waker-fn` crate. (#81)
+
 # Version 2.0.0
 
 - **Breaking:** Expose `future::{ready, pending}` from `core` instead of defining

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "futures-lite"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.0.0"
+version = "2.0.1"
 authors = [
   "Stjepan Glavina <stjepang@gmail.com>",
   "Contributors to futures-rs",


### PR DESCRIPTION
- Remove dependency on the `waker-fn` crate. (#81)
