### PR TITLE
v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 2.1.0
+
+- Make it so `read_line` and other futures use a naive implementation of byte
+  searching unless the `memchr` feature is enabled. This prevents needing to
+  compile the `memchr` crate unless it is desired. (#77)
+
 # Version 2.0.1
 
 - Remove dependency on the `waker-fn` crate. (#81)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "futures-lite"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.0.1"
+version = "2.1.0"
 authors = [
   "Stjepan Glavina <stjepang@gmail.com>",
   "Contributors to futures-rs",


### PR DESCRIPTION
- Make it so `read_line` and other futures use a naive implementation of byte searching unless the `memchr` feature is enabled. This prevents needing to compile the `memchr` crate unless it is desired. (#77)
