### PR TITLE
Relax MSRV to 1.60 & Migrate to Rust 2021

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,16 +49,12 @@ jobs:
 
   msrv:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # When updating this, the reminder to update the minimum supported
-        # Rust version in Cargo.toml.
-        rust: ['1.61']
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-      - run: cargo build
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      # memchr feature can have a higher MSRV.
+      - run: cargo hack build --feature-powerset --skip memchr --rust-version
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
   "Stjepan Glavina <stjepang@gmail.com>",
   "Contributors to futures-rs",
 ]
-edition = "2018"
+edition = "2021"
 rust-version = "1.60"
 description = "Futures, streams, and async I/O combinators"
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
   "Contributors to futures-rs",
 ]
 edition = "2018"
-rust-version = "1.61"
+rust-version = "1.60"
 description = "Futures, streams, and async I/O combinators"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/smol-rs/futures-lite"


### PR DESCRIPTION
- Relax MSRV to 1.60
  Since https://github.com/smol-rs/futures-lite/pull/77, this crate works on 1.60.
- Migrate to Rust 2021
- Use cargo-hack's --rust-version flag for msrv check
  This respects rust-version field in Cargo.toml, so it removes the need to manage MSRV in both the CI file and Cargo.toml.
