### PR TITLE
Fix clippy::redundant_guards warning

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -2698,9 +2698,7 @@ impl<R1: AsyncBufRead, R2: AsyncBufRead> AsyncBufRead for Chain<R1, R2> {
         let this = self.project();
         if !*this.done_first {
             match ready!(this.first.poll_fill_buf(cx)) {
-                Ok(buf) if buf.is_empty() => {
-                    *this.done_first = true;
-                }
+                Ok([]) => *this.done_first = true,
                 Ok(buf) => return Poll::Ready(Ok(buf)),
                 Err(err) => return Poll::Ready(Err(err)),
             }


### PR DESCRIPTION
```
warning: redundant guard
    --> src/io.rs:2701:28
     |
2701 |                 Ok(buf) if buf.is_empty() => {
     |                            ^^^^^^^^^^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_guards
     = note: `#[warn(clippy::redundant_guards)]` on by default
help: try
     |
2701 -                 Ok(buf) if buf.is_empty() => {
2701 +                 Ok([]) => {
     |
```

(This lint is not yet available on stable)