### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 2.2.0
+
+- Relax `Unpin` bounds on `io::copy`. (#87)
+- Implement `size_hint` for `stream::Filter`. (#88)
+- Relax MSRV to 1.60. (#90)
+
 # Version 2.1.0
 
 - Make it so `read_line` and other futures use a naive implementation of byte

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "futures-lite"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.1.0"
+version = "2.2.0"
 authors = [
   "Stjepan Glavina <stjepang@gmail.com>",
   "Contributors to futures-rs",


### PR DESCRIPTION
Changes:

- Relax `Unpin` bounds on `io::copy`. (#87)
- Implement `size_hint` for `stream::Filter`. (#88)
- Relax MSRV to 1.60. (#90)