### PR TITLE
StreamExt: add chunks and try_chunks

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1861,6 +1861,78 @@ pub trait StreamExt: Stream {
     {
         Box::pin(self)
     }
+
+    /// An adaptor for chunking up items of the stream inside a vector.
+    ///
+    /// This combinator will attempt to pull items from this stream and buffer
+    /// them into a local vector. At most `capacity` items will get buffered
+    /// before they're yielded from the returned stream.
+    ///
+    /// Note that the vectors returned from this iterator may not always have
+    /// `capacity` elements. If the underlying stream ended and only a partial
+    /// vector was created, it'll be returned. Additionally if an error happens
+    /// from the underlying stream then the currently buffered items will be
+    /// yielded.
+    ///
+    /// This method is only available when the `alloc` feature of this
+    /// library is activated.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `capacity` is zero.
+    #[cfg(feature = "alloc")]
+    fn chunks(self, capacity: usize) -> Chunks<Self>
+    where
+        Self: Sized,
+    {
+        Chunks::new(self, capacity)
+    }
+
+    /// An adaptor for chunking up successful items of the stream inside a vector.
+    ///
+    /// This combinator will attempt to pull successful items from this stream and buffer
+    /// them into a local vector. At most `capacity` items will get buffered
+    /// before they're yielded from the returned stream.
+    ///
+    /// Note that the vectors returned from this iterator may not always have
+    /// `capacity` elements. If the underlying stream ended and only a partial
+    /// vector was created, it'll be returned. Additionally if an error happens
+    /// from the underlying stream then the currently buffered items will be
+    /// yielded.
+    ///
+    /// This method is only available when the `std` or `alloc` feature of this
+    /// library is activated, and it is activated by default.
+    ///
+    /// This function is similar to
+    /// [`StreamExt::chunks`](StreamExt::chunks) but exits
+    /// early if an error occurs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # spin_on::spin_on(async {
+    /// use futures_lite::stream::{self, TryChunksError, StreamExt};
+    ///
+    /// let stream = stream::iter(vec![Ok::<i32, i32>(1), Ok(2), Ok(3), Err(4), Ok(5), Ok(6)]);
+    /// let mut stream = stream.try_chunks(2);
+    ///
+    /// assert_eq!(stream.try_next().await, Ok(Some(vec![1, 2])));
+    /// assert_eq!(stream.try_next().await, Err(TryChunksError(vec![3], 4)));
+    /// assert_eq!(stream.try_next().await, Ok(Some(vec![5, 6])));
+    /// # })
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `capacity` is zero.
+    #[cfg(feature = "alloc")]
+    fn try_chunks<T, E>(self, capacity: usize) -> TryChunks<Self, T>
+    where
+        Self: Sized,
+        Self: Stream<Item = Result<T, E>>,
+    {
+        TryChunks::new(self, capacity)
+    }
 }
 
 impl<S: Stream + ?Sized> StreamExt for S {}
@@ -3310,3 +3382,175 @@ impl<'a, S: Stream + Unpin + ?Sized> Stream for Drain<'a, S> {
         (0, hi)
     }
 }
+
+pin_project! {
+    /// Stream for the [`chunks`](StreamExt::chunks) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Chunks<S: Stream> {
+        #[pin]
+        stream: S,
+        items: Vec<S::Item>,
+        cap: usize, // https://github.com/rust-lang/futures-rs/issues/1475
+    }
+}
+
+impl<S: Stream> Chunks<S> {
+    pub(super) fn new(stream: S, capacity: usize) -> Self {
+        assert!(capacity > 0);
+
+        Self {
+            stream,
+            items: Vec::with_capacity(capacity),
+            cap: capacity,
+        }
+    }
+
+    fn take(self: Pin<&mut Self>) -> Vec<S::Item> {
+        let cap = self.cap;
+        mem::replace(self.project().items, Vec::with_capacity(cap))
+    }
+}
+
+impl<S: Stream> Stream for Chunks<S> {
+    type Item = Vec<S::Item>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.as_mut().project();
+        loop {
+            match ready!(this.stream.as_mut().poll_next(cx)) {
+                // Push the item into the buffer and check whether it is full.
+                // If so, replace our buffer with a new and empty one and return
+                // the full one.
+                Some(item) => {
+                    this.items.push(item);
+                    if this.items.len() >= *this.cap {
+                        return Poll::Ready(Some(self.take()));
+                    }
+                }
+
+                // Since the underlying stream ran out of values, return what we
+                // have buffered, if we have anything.
+                None => {
+                    let last = if this.items.is_empty() {
+                        None
+                    } else {
+                        let full_buf = mem::take(this.items);
+                        Some(full_buf)
+                    };
+
+                    return Poll::Ready(last);
+                }
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, upper) = self.stream.size_hint();
+        let len = self.items.len();
+        let lower = lower.saturating_add(len).div_ceil(self.cap);
+        let upper = upper
+            .and_then(|u| u.checked_add(len))
+            .map(|u| u.div_ceil(self.cap));
+        (lower, upper)
+    }
+}
+
+pin_project! {
+    /// Stream for the [`try_chunks`](StreamExt::try_chunks) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct TryChunks<S, T> {
+        #[pin]
+        stream: S,
+        items: Vec<T>,
+        cap: usize, // https://github.com/rust-lang/futures-rs/issues/1475
+    }
+}
+
+impl<S, T> TryChunks<S, T> {
+    pub(super) fn new(stream: S, capacity: usize) -> Self {
+        assert!(capacity > 0);
+
+        Self {
+            stream,
+            items: Vec::with_capacity(capacity),
+            cap: capacity,
+        }
+    }
+
+    fn take(self: Pin<&mut Self>) -> Vec<T> {
+        let cap = self.cap;
+        mem::replace(self.project().items, Vec::with_capacity(cap))
+    }
+}
+
+impl<S: Stream<Item = Result<T, E>>, T, E> Stream for TryChunks<S, T> {
+    type Item = Result<Vec<T>, TryChunksError<T, E>>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.as_mut().project();
+        loop {
+            match ready!(this.stream.as_mut().poll_next(cx)) {
+                // Push the item into the buffer and check whether it is full.
+                // If so, replace our buffer with a new and empty one and return
+                // the full one.
+                Some(item) => match item {
+                    Ok(item) => {
+                        this.items.push(item);
+                        if this.items.len() >= *this.cap {
+                            return Poll::Ready(Some(Ok(self.take())));
+                        }
+                    }
+                    Err(e) => {
+                        return Poll::Ready(Some(Err(TryChunksError(self.take(), e))));
+                    }
+                },
+
+                // Since the underlying stream ran out of values, return what we
+                // have buffered, if we have anything.
+                None => {
+                    let last = if this.items.is_empty() {
+                        None
+                    } else {
+                        let full_buf = mem::take(this.items);
+                        Some(full_buf)
+                    };
+
+                    return Poll::Ready(last.map(Ok));
+                }
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, upper) = self.stream.size_hint();
+        let len = self.items.len();
+        let lower = lower.saturating_add(len).div_ceil(self.cap);
+        let upper = upper
+            .and_then(|u| u.checked_add(len))
+            .map(|u| u.div_ceil(self.cap));
+        (lower, upper)
+    }
+}
+
+/// Error indicating, that while chunk was collected inner stream produced an error.
+///
+/// Contains all items that were collected before an error occurred, and the stream error itself.
+#[derive(PartialEq, Eq)]
+pub struct TryChunksError<T, E>(pub Vec<T>, pub E);
+
+impl<T, E: fmt::Debug> fmt::Debug for TryChunksError<T, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.1.fmt(f)
+    }
+}
+
+impl<T, E: fmt::Display> fmt::Display for TryChunksError<T, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.1.fmt(f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T, E: fmt::Debug + fmt::Display> std::error::Error for TryChunksError<T, E> {}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -23,6 +23,8 @@ pub use futures_core::stream::Stream;
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::boxed::Box;
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::vec::Vec;
 
 use core::fmt;
 use core::future::Future;
@@ -3383,6 +3385,7 @@ impl<'a, S: Stream + Unpin + ?Sized> Stream for Drain<'a, S> {
     }
 }
 
+#[cfg(feature = "alloc")]
 pin_project! {
     /// Stream for the [`chunks`](StreamExt::chunks) method.
     #[derive(Debug)]
@@ -3395,6 +3398,7 @@ pin_project! {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<S: Stream> Chunks<S> {
     pub(super) fn new(stream: S, capacity: usize) -> Self {
         assert!(capacity > 0);
@@ -3412,6 +3416,7 @@ impl<S: Stream> Chunks<S> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<S: Stream> Stream for Chunks<S> {
     type Item = Vec<S::Item>;
 
@@ -3456,6 +3461,7 @@ impl<S: Stream> Stream for Chunks<S> {
     }
 }
 
+#[cfg(feature = "alloc")]
 pin_project! {
     /// Stream for the [`try_chunks`](StreamExt::try_chunks) method.
     #[derive(Debug)]
@@ -3468,6 +3474,7 @@ pin_project! {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<S, T> TryChunks<S, T> {
     pub(super) fn new(stream: S, capacity: usize) -> Self {
         assert!(capacity > 0);
@@ -3485,6 +3492,7 @@ impl<S, T> TryChunks<S, T> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<S: Stream<Item = Result<T, E>>, T, E> Stream for TryChunks<S, T> {
     type Item = Result<Vec<T>, TryChunksError<T, E>>;
 
@@ -3537,15 +3545,18 @@ impl<S: Stream<Item = Result<T, E>>, T, E> Stream for TryChunks<S, T> {
 /// Error indicating, that while chunk was collected inner stream produced an error.
 ///
 /// Contains all items that were collected before an error occurred, and the stream error itself.
+#[cfg(feature = "alloc")]
 #[derive(PartialEq, Eq)]
 pub struct TryChunksError<T, E>(pub Vec<T>, pub E);
 
+#[cfg(feature = "alloc")]
 impl<T, E: fmt::Debug> fmt::Debug for TryChunksError<T, E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.1.fmt(f)
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, E: fmt::Display> fmt::Display for TryChunksError<T, E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.1.fmt(f)


### PR DESCRIPTION
I love this crate a lot because of its wonderful api and elegant implement. I really need `chunks` and `try_chunks` method for `StreamExt`, which is missing in this crate. So I forked this repo, and added them. And I wonder if this could be merged.

The codes are mainly from `futures-rs` with some changes:

1. Remove `Sink` and `FusedStream` related things
2. Remove references to `TryStream`
3. Rename type parameter `St` to `S`
4. fix size_hints as mentioned [here](https://github.com/rust-lang/futures-rs/issues/2610#issuecomment-2016470303)
5. rewrite some inline docs to fit `futures-lite` and changes above

Thanks a lot for your reviewing this :)