### PR TITLE
fix: drop completed futures in `Zip` and `TryZip`

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -383,7 +383,7 @@ impl<T: Clone> Stream for Repeat<T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (usize::max_value(), None)
+        (usize::MAX, None)
     }
 }
 
@@ -429,7 +429,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (usize::max_value(), None)
+        (usize::MAX, None)
     }
 }
 


### PR DESCRIPTION
Fixes #105