### PR TITLE
fix: remove `Unpin` from lines

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -1692,7 +1692,7 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     /// ```
     fn lines(self) -> Lines<Self>
     where
-        Self: Unpin + Sized,
+        Self: Sized,
     {
         Lines {
             reader: self,


### PR DESCRIPTION
Is `Unpin` really needed here?
The lines method takes `self` as a value and pins inside `Lines` struct, so there is no need to require `Unpin`