### PR TITLE
v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.5.0
+
+- Remove `Unpin` bound from the `Lines` I/O adapter. (#113)
+
 # Version 2.4.0
 
 - Add a "fuse" method that makes it so a `Future` returns `Poll::Pending`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "futures-lite"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.4.0"
+version = "2.5.0"
 authors = [
   "Stjepan Glavina <stjepang@gmail.com>",
   "Contributors to futures-rs",


### PR DESCRIPTION
- Remove `Unpin` bound from the `Lines` I/O adapter. (#113)
