### PR TITLE
update fastrand dependency to 2.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ alloc = []
 race = ["fastrand"]
 
 [dependencies]
-fastrand = { version = "2.0.0", optional = true, default-features = false }
+fastrand = { version = "2.2.0", optional = true, default-features = false }
 futures-core = { version = "0.3.5", default-features = false }
 futures-io = { version = "0.3.5", optional = true }
 memchr = { version = "2.3.3", optional = true }


### PR DESCRIPTION
In a personal project, I encountered a conflict between `fastrand 2.1.0` and `fastrand 2.0.1` used by `futures-lite`.  Hence this PR. Is it OK to bump up the version of `fastrand`? 