### PR TITLE
Update read_exact docs

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -2070,8 +2070,6 @@ pub trait AsyncReadExt: AsyncRead {
 
     /// Reads the exact number of bytes required to fill `buf`.
     ///
-    /// On success, returns the total number of bytes read.
-    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
I may be missing something, but I don't think that `AsyncReadExt::read_exact` returns the number of bytes read. It seems like it returns an `impl Future<Output = std::io::Result<()>>`.