### PR TITLE
feat: add `stream::from_fn`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       - run: cargo test
       - run: cargo test --no-default-features
       - run: cargo test --no-default-features --features alloc
+      - run: cargo test --all-features
 
   msrv:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ default = ["race", "std"]
 std = ["alloc", "fastrand/std", "futures-io", "parking"]
 alloc = []
 race = ["fastrand"]
+async-closure = []
 
 [dependencies]
 fastrand = { version = "2.0.0", optional = true, default-features = false }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -664,7 +664,7 @@ where
 /// Then the function takes `impl AsyncFnMut() -> Option<T>` and you can
 /// directly use async closures:
 ///
-/// ```rust,ignore
+/// ```rust
 /// use futures_lite::stream::{self, StreamExt};
 ///
 /// # spin_on::spin_on(async {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -702,6 +702,7 @@ where
 #[cfg(feature = "async-closure")]
 mod private {
     use core::future::Future;
+    use core::ops::AsyncFnMut;
 
     pub trait AsyncClosure<R> {
         fn call(&mut self) -> impl Future<Output = R>;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -667,23 +667,26 @@ where
 /// ```rust
 /// use futures_lite::stream::{self, StreamExt};
 ///
-/// # spin_on::spin_on(async {
-/// let mut n = 0;
-/// let s = stream::from_fn(async || {
-///     if n < 2 {
-///         let prev = n;
+/// #[cfg(feature = "async-closure")]
+/// {
+/// #   spin_on::spin_on(async {
+///     let mut n = 0;
+///     let s = stream::from_fn(async || {
+///         if n < 2 {
+///             let prev = n;
 ///
-///         // Mutates the state inside the future.
-///         n += 1;
-///         Some(prev)
-///     } else {
-///         None
-///     }
-/// });
+///             // Mutates the state inside the future.
+///             n += 1;
+///             Some(prev)
+///         } else {
+///             None
+///         }
+///     });
 ///
-/// let v: Vec<i32> = s.collect().await;
-/// assert_eq!(v, [0, 1]);
-/// # })
+///     let v: Vec<i32> = s.collect().await;
+///     assert_eq!(v, [0, 1]);
+/// #   })
+/// }
 /// ```
 pub fn from_fn<F, T>(f: F) -> impl Stream<Item = T>
 where

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -668,25 +668,21 @@ where
 /// use futures_lite::stream::{self, StreamExt};
 ///
 /// # spin_on::spin_on(async {
-/// // Assume the feature is enabled.
-/// #[cfg(feature = "async-closure")]
-/// {
-///     let mut n = 0;
-///     let s = stream::from_fn(async || {
-///         if n < 2 {
-///             let prev = n;
+/// let mut n = 0;
+/// let s = stream::from_fn(async || {
+///     if n < 2 {
+///         let prev = n;
 ///
-///             // Mutates the state inside the future.
-///             n += 1;
-///             Some(prev)
-///         } else {
-///             None
-///         }
-///     });
+///         // Mutates the state inside the future.
+///         n += 1;
+///         Some(prev)
+///     } else {
+///         None
+///     }
+/// });
 ///
-///     let v: Vec<i32> = s.collect().await;
-///     assert_eq!(v, [0, 1]);
-/// }
+/// let v: Vec<i32> = s.collect().await;
+/// assert_eq!(v, [0, 1]);
 /// # })
 /// ```
 pub fn from_fn<F, T>(f: F) -> impl Stream<Item = T>

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -657,7 +657,7 @@ where
 ///
 /// While this limitations can be circumvented using types like `Rc/Arc` to
 /// avoid references and types with interior mutability to allow mutate a
-/// state, it's much easier to use [async closures](std::ops::AsyncFnMut).
+/// state, it's much easier to use [async closures](core::ops::AsyncFnMut).
 /// It requires Rust 1.85 or later and the `async-closure` feature must
 /// be enabled.
 ///
@@ -701,7 +701,7 @@ where
 
 #[cfg(feature = "async-closure")]
 mod private {
-    use std::future::Future;
+    use core::future::Future;
 
     pub trait AsyncClosure<R> {
         fn call(&mut self) -> impl Future<Output = R>;
@@ -719,7 +719,7 @@ mod private {
 
 #[cfg(not(feature = "async-closure"))]
 mod private {
-    use std::future::Future;
+    use core::future::Future;
 
     pub trait AsyncClosure<R> {
         type Future: Future<Output = R>;


### PR DESCRIPTION
This adds an analogue of [`std::iter::from_fn`](https://doc.rust-lang.org/std/iter/fn.from_fn.html) for streams.

Also creates a new feature `async-closure` that allows to use newer compiler version 1.85 or later to use async closures. Crates for older versions may use this function without the feature but it'll be more limited.