### PR TITLE
docs: Enable doc_auto_cfg on docs.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
 )]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "std")]
 #[doc(no_inline)]


### PR DESCRIPTION
This adds the small feature pills that you see on many crates on docs.rs nowadays.

Tested locally with `RUSTDOCFLAGS='--cfg=docsrs' cargo doc --open --all-features`:

![Screenshot 2025-02-04 at 21-18-10 futures_lite - Rust](https://github.com/user-attachments/assets/bea02d58-f5ef-45cb-aebc-5133fe622d7d)
![Screenshot 2025-02-04 at 21-18-23 futures_lite future - Rust](https://github.com/user-attachments/assets/cd686693-7b56-4ad9-bb55-531ad2a232cb)
