### PR TITLE
v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.6.1
+
+- Fix docs for `once_future` and `stop_after_future`. (#131)
+
 # Version 2.6.0
 
 - Add `Stream::map_while()` combinator. (#116)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "futures-lite"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.6.0"
+version = "2.6.1"
 authors = [
   "Stjepan Glavina <stjepang@gmail.com>",
   "Contributors to futures-rs",


### PR DESCRIPTION
- Fix docs for `once_future` and `stop_after_future`. (#131)
- Switch to unconditional `no_std`. (#128)